### PR TITLE
Fixing test to compare case classes with actually identical names

### DIFF
--- a/modules/examples/src/test/scala/com/fortysevendeg/examples/Models.scala
+++ b/modules/examples/src/test/scala/com/fortysevendeg/examples/Models.scala
@@ -2,13 +2,21 @@ package com.fortysevendeg.examples
 
 import com.fortysevendeg.macros.ToStringObfuscate
 
-@ToStringObfuscate("password", "pinCode")
-case class TestObfuscatePassword(name: String, username : String, password : String, pinCode: String)
+object Obfuscated {
 
-@ToStringObfuscate("cardNumber")
-case class TestObfuscateCreditCard(cardNumber: String, cvv : Int, endDate: String)
+  @ToStringObfuscate("password", "pinCode")
+  case class TestObfuscatePassword(name: String, username: String, password: String, pinCode: String)
 
-@ToStringObfuscate("password")
-case class TestWithObfuscation(username : String, password : String)
+  @ToStringObfuscate("cardNumber")
+  case class TestObfuscateCreditCard(cardNumber: String, cvv: Int, endDate: String)
 
-case class TestWithoutObfuscation(username : String, password : String)
+  @ToStringObfuscate("password")
+  case class UserPassword(username: String, password: String)
+
+}
+
+object NonObfuscated {
+
+  case class UserPassword(username: String, password: String)
+
+}

--- a/modules/examples/src/test/scala/com/fortysevendeg/examples/ObfuscateSpec.scala
+++ b/modules/examples/src/test/scala/com/fortysevendeg/examples/ObfuscateSpec.scala
@@ -5,6 +5,7 @@ import java.util.UUID
 import org.scalatest.{Matchers, WordSpec}
 
 import scala.util.Random
+import com.fortysevendeg.examples.Obfuscated._
 
 class ObfuscateSpec extends WordSpec with Matchers {
 
@@ -50,12 +51,12 @@ class ObfuscateSpec extends WordSpec with Matchers {
     val username = generateUUID
     val password = generateUUID
 
-    val obfuscatedInstance = TestWithObfuscation(
+    val obfuscatedInstance = UserPassword(
       username = username,
       password = password
     )
 
-    val nonObfuscatedInstance = TestWithoutObfuscation(
+    val nonObfuscatedInstance = NonObfuscated.UserPassword(
       username = username,
       password = password
     )


### PR DESCRIPTION
The test "`toString` method in identical case classes are different when one of them obfuscate one of his fields" used case classes with different names, which means that the test would have passed even if the password had not been obfuscated.

This change wraps the models in objects (could have used a package as well) so that they can have identical names and therefore identical string representations, except for the obfuscation